### PR TITLE
Add missing close paren in documentation 

### DIFF
--- a/README
+++ b/README
@@ -119,7 +119,7 @@ SUBROUTINES/METHODS
   Mock Stats
     When creating mocked files or directories, we default their stats to:
 
-        Test::MockFile->new( $file, $contents, {
+        Test::MockFile->file( $file, $contents, {
                 'dev'       => 0,        # stat[0]
                 'inode'     => 0,        # stat[1]
                 'mode'      => $mode,    # stat[2]
@@ -132,7 +132,7 @@ SUBROUTINES/METHODS
                 'ctime'     => $now,     # stat[10]
                 'blksize'   => 4096,     # stat[11]
                 'fileno'    => undef,    # fileno()
-        };
+        } );
 
     You'll notice that mode, size, and blocks have been left out of this.
     Mode is set to 666 (for files) or 777 (for directories), xored against

--- a/README.mkdn
+++ b/README.mkdn
@@ -117,7 +117,7 @@ See ["Mock Stats"](#mock-stats) for what goes in this hash ref.
 
 When creating mocked files or directories, we default their stats to:
 
-    Test::MockFile->new( $file, $contents, {
+    Test::MockFile->file( $file, $contents, {
             'dev'       => 0,        # stat[0]
             'inode'     => 0,        # stat[1]
             'mode'      => $mode,    # stat[2]
@@ -130,7 +130,7 @@ When creating mocked files or directories, we default their stats to:
             'ctime'     => $now,     # stat[10]
             'blksize'   => 4096,     # stat[11]
             'fileno'    => undef,    # fileno()
-    };
+    } );
     
 
 You'll notice that mode, size, and blocks have been left out of this. Mode is set to 666 (for files) or 777 (for directories), xored against the current umask.

--- a/lib/Test/MockFile.pm
+++ b/lib/Test/MockFile.pm
@@ -357,7 +357,7 @@ When creating mocked files or directories, we default their stats to:
             'ctime'     => $now,     # stat[10]
             'blksize'   => 4096,     # stat[11]
             'fileno'    => undef,    # fileno()
-    });
+    } );
     
 You'll notice that mode, size, and blocks have been left out of this. Mode is set to 666 (for files) or 777 (for directories), xored against the current umask.
 Size and blocks are calculated based on the size of 'contents' a.k.a. the fake file.


### PR DESCRIPTION
    Add missing paren in code samples

    Documenation for 'Mock Stats' was missing
    a close paren in the code snippet.