### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -1,5 +1,8 @@
 name: testsuite
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/cpanel/Test-MockFile/security/code-scanning/2](https://github.com/cpanel/Test-MockFile/security/code-scanning/2)

In general, this problem is fixed by adding an explicit `permissions` block to the workflow or to each job, limiting the `GITHUB_TOKEN` to the least privileges required. For a workflow that only checks out code and runs tests, `contents: read` is typically sufficient.

The best fix here without changing existing functionality is to define a workflow-level `permissions` block just under the `name:` (and before `on:`), setting `contents: read`. This will apply to all jobs (`ubuntu` and `perl`) since neither currently defines its own `permissions` block, and both only need to read repository contents via `actions/checkout@v4`. No other scopes (such as `pull-requests`, `issues`, or `packages`) are required by the given steps.

Concretely, in `.github/workflows/testsuite.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: testsuite`) and line 3 (`on:`). No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
